### PR TITLE
Adding possibility to load an HF-dataset

### DIFF
--- a/scripts/load_dataset.py
+++ b/scripts/load_dataset.py
@@ -38,19 +38,17 @@ data_dir = args.data_dir
 save_dir = args.save_dir
 dataset_name = args.name
 
-ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2 ** 16,
+
+ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
                data_dir=data_dir)
 assert isinstance(ds, tf.data.Dataset)
 print(ds)
 
 UID = 0
-
-
 def sep():
     global UID
     UID += 1
-    return b"\xff\xff" + struct.pack("<I", UID)
-
+    return b"\xff\xff"+struct.pack("<I", UID)
 
 def tok(x):
     if args.tokenize:
@@ -61,7 +59,7 @@ def tok(x):
     return out
 
 
-fout = open(os.path.join(save_dir, dataset_name + "." + split), "wb")
+fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
 
 p = mp.Pool(96)
 
@@ -71,13 +69,12 @@ for b in ds:
     print(i)
 
     text = b['text'].numpy()
-    text = p.map(tok, text)
-
+    text = p.map(tok,text)
+    
     for x in text:
-        next_line = sep() + x
+        next_line = sep()+x
         fout.write(next_line)
-        sizes.append(sizes[-1] + len(next_line))
+        sizes.append(sizes[-1]+len(next_line))
     i += 1
 
-open(os.path.join(save_dir, dataset_name + "." + split + ".size"), "wb").write(
-    np.array(sizes, dtype=np.uint64).tobytes())
+open(os.path.join(save_dir,dataset_name+"."+split+".size"), "wb").write(np.array(sizes,dtype=np.uint64).tobytes())

--- a/scripts/load_dataset.py
+++ b/scripts/load_dataset.py
@@ -13,6 +13,7 @@
 
 import tensorflow_datasets as tfds
 import tensorflow as tf
+import datasets
 import os
 import struct
 import numpy as np
@@ -25,8 +26,12 @@ parser = argparse.ArgumentParser(description='Load a dataset.')
 parser.add_argument('--data_dir', type=str)
 parser.add_argument('--save_dir', type=str)
 parser.add_argument('--name', type=str)
+parser.add_argument('--dataset_format', type=str, default="tfds")
 parser.add_argument('--split', type=str)
+parser.add_argument('--hf_ds_subset', type=str, default=None)
 parser.add_argument('--tokenize', action='store_true')
+parser.add_argument('--text_feature_key', type=str, default="text")
+parser.add_argument('--num_workers', type=int, default=1)
 
 args = parser.parse_args()
 
@@ -37,12 +42,21 @@ split = args.split
 data_dir = args.data_dir
 save_dir = args.save_dir
 dataset_name = args.name
+dataset_format = args.dataset_format
+key = args.text_feature_key
+num_workers = args.num_workers
 
 
-ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
-               data_dir=data_dir)
-assert isinstance(ds, tf.data.Dataset)
-print(ds)
+if dataset_format == "tfds":
+    ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
+                   data_dir=data_dir)
+    assert isinstance(ds, tf.data.Dataset)
+    print(ds)
+elif dataset_format == "hf":
+    subset = args.hf_ds_subset
+    ds = datasets.load_dataset(dataset_name, subset, split=split)
+    assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
+    print(ds)
 
 UID = 0
 def sep():
@@ -52,24 +66,35 @@ def sep():
 
 def tok(x):
     if args.tokenize:
-        out = tokenizer.encode(x.decode("utf8"))
+        if dataset_format == "tfds":
+            x = x.numpy().decode("utf8")
+        out = tokenizer.encode(x)
         out = np.array(out, dtype=np.uint16).view(np.uint8).tobytes()
     else:
-        out = x
+        if dataset_format == "hf":
+            x = x.encode("utf8")
+        out = x.numpy()
     return out
 
 
+os.makedirs(save_dir, exist_ok=True)
 fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
 
-p = mp.Pool(96)
+if num_workers > 1:
+    p = mp.Pool(96)
+else:
+    p = None
 
 i = 0
 sizes = [0]
 for b in ds:
     print(i)
 
-    text = b['text'].numpy()
-    text = p.map(tok,text)
+    text = b[key]
+    if num_workers > 1:
+        text = p.map(tok,text)
+    else:
+        text = map(tok, text)
     
     for x in text:
         next_line = sep()+x

--- a/scripts/load_dataset.py
+++ b/scripts/load_dataset.py
@@ -13,7 +13,6 @@
 
 import tensorflow_datasets as tfds
 import tensorflow as tf
-import datasets
 import os
 import struct
 import numpy as np
@@ -26,12 +25,8 @@ parser = argparse.ArgumentParser(description='Load a dataset.')
 parser.add_argument('--data_dir', type=str)
 parser.add_argument('--save_dir', type=str)
 parser.add_argument('--name', type=str)
-parser.add_argument('--dataset_format', type=str, default="tfds")
 parser.add_argument('--split', type=str)
-parser.add_argument('--hf_ds_subset', type=str, default=None)
 parser.add_argument('--tokenize', action='store_true')
-parser.add_argument('--text_feature_key', type=str, default="text")
-parser.add_argument('--num_workers', type=int, default=1)
 
 args = parser.parse_args()
 
@@ -42,64 +37,47 @@ split = args.split
 data_dir = args.data_dir
 save_dir = args.save_dir
 dataset_name = args.name
-dataset_format = args.dataset_format
-key = args.text_feature_key
-num_workers = args.num_workers
 
-
-if dataset_format == "tfds":
-    ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
-                   data_dir=data_dir)
-    assert isinstance(ds, tf.data.Dataset)
-    print(ds)
-elif dataset_format == "hf":
-    subset = args.hf_ds_subset
-    ds = datasets.load_dataset(dataset_name, subset, split=split)
-    assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
-    print(ds)
+ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2 ** 16,
+               data_dir=data_dir)
+assert isinstance(ds, tf.data.Dataset)
+print(ds)
 
 UID = 0
+
+
 def sep():
     global UID
     UID += 1
-    return b"\xff\xff"+struct.pack("<I", UID)
+    return b"\xff\xff" + struct.pack("<I", UID)
+
 
 def tok(x):
     if args.tokenize:
-        if dataset_format == "tfds":
-            x = x.numpy().decode("utf8")
-        out = tokenizer.encode(x)
+        out = tokenizer.encode(x.decode("utf8"))
         out = np.array(out, dtype=np.uint16).view(np.uint8).tobytes()
     else:
-        if dataset_format == "hf":
-            x = x.encode("utf8")
-        out = x.numpy()
+        out = x
     return out
 
 
-os.makedirs(save_dir, exist_ok=True)
-fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
+fout = open(os.path.join(save_dir, dataset_name + "." + split), "wb")
 
-if num_workers > 1:
-    p = mp.Pool(96)
-else:
-    p = None
+p = mp.Pool(96)
 
 i = 0
 sizes = [0]
 for b in ds:
     print(i)
 
-    text = b[key]
-    if num_workers > 1:
-        text = p.map(tok,text)
-    else:
-        text = map(tok, text)
-    
+    text = b['text'].numpy()
+    text = p.map(tok, text)
+
     for x in text:
-        next_line = sep()+x
+        next_line = sep() + x
         fout.write(next_line)
-        sizes.append(sizes[-1]+len(next_line))
+        sizes.append(sizes[-1] + len(next_line))
     i += 1
 
-open(os.path.join(save_dir,dataset_name+"."+split+".size"), "wb").write(np.array(sizes,dtype=np.uint64).tobytes())
+open(os.path.join(save_dir, dataset_name + "." + split + ".size"), "wb").write(
+    np.array(sizes, dtype=np.uint64).tobytes())

--- a/scripts/load_dataset_hf.py
+++ b/scripts/load_dataset_hf.py
@@ -17,13 +17,17 @@ import struct
 import numpy as np
 from transformers import GPT2Tokenizer
 from tqdm import tqdm
+import glob
 
 import argparse
 
+
+FILE_EXTENSIONS = {"text": "txt", "json": "jsonl", "csv": "csv"}
+
 parser = argparse.ArgumentParser(description='Load a dataset.')
-parser.add_argument('--data_dir', type=str)
 parser.add_argument('--save_dir', type=str)
 parser.add_argument('--name', type=str)
+parser.add_argument('--data_dir', type=str, default=None)
 parser.add_argument('--split', type=str)
 parser.add_argument('--subset', type=str, default=None)
 parser.add_argument('--tokenize', action='store_true')
@@ -35,8 +39,8 @@ args = parser.parse_args()
 if args.tokenize:
     tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
 
-data_dir = args.data_dir
 save_dir = args.save_dir
+data_dir = args.data_dir
 dataset_name = args.name
 split = args.split
 subset = args.subset
@@ -44,7 +48,12 @@ tokenize = args.tokenize
 num_workers = args.num_workers
 key = args.text_feature_key
 
-ds = datasets.load_dataset(dataset_name, subset, split=split)
+if dataset_name in FILE_EXTENSIONS:
+    assert data_dir is not None
+    data_files = glob.glob(f"{data_dir}/*.{FILE_EXTENSIONS[dataset_name]}")
+    ds = datasets.load_dataset(dataset_name, subset, data_files=data_files, split=split)
+else:
+    ds = datasets.load_dataset(dataset_name, subset, split=split)
 assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
 
 UID = 0

--- a/scripts/load_dataset_hf.py
+++ b/scripts/load_dataset_hf.py
@@ -11,14 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow_datasets as tfds
-import tensorflow as tf
 import datasets
 import os
 import struct
 import numpy as np
 from transformers import GPT2Tokenizer
-import multiprocessing as mp
 
 import argparse
 
@@ -26,84 +23,62 @@ parser = argparse.ArgumentParser(description='Load a dataset.')
 parser.add_argument('--data_dir', type=str)
 parser.add_argument('--save_dir', type=str)
 parser.add_argument('--name', type=str)
-parser.add_argument('--dataset_format', type=str, default="tfds")
 parser.add_argument('--split', type=str)
-parser.add_argument('--hf_ds_subset', type=str, default=None)
+parser.add_argument('--subset', type=str, default=None)
 parser.add_argument('--tokenize', action='store_true')
 parser.add_argument('--text_feature_key', type=str, default="text")
-parser.add_argument('--num_workers', type=int, default=1)
 
 args = parser.parse_args()
 
 if args.tokenize:
     tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
 
-split = args.split
 data_dir = args.data_dir
 save_dir = args.save_dir
+split = args.split
+subset = args.subset
 dataset_name = args.name
-dataset_format = args.dataset_format
 key = args.text_feature_key
-num_workers = args.num_workers
+tokenize = args.tokenize
 
-
-if dataset_format == "tfds":
-    ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
-                   data_dir=data_dir)
-    assert isinstance(ds, tf.data.Dataset)
-    print(ds)
-elif dataset_format == "hf":
-    subset = args.hf_ds_subset
-    ds = datasets.load_dataset(dataset_name, subset, split=split)
-    assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
-    print(ds)
+ds = datasets.load_dataset(dataset_name, subset, split=split)
+assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
 
 UID = 0
+
+
 def sep():
     global UID
     UID += 1
-    return b"\xff\xff"+struct.pack("<I", UID)
+    return b"\xff\xff" + struct.pack("<I", UID)
 
-def tok(x):
-    if args.tokenize:
-        if dataset_format == "tfds":
-            x = x.numpy().decode("utf8")
-        out = tokenizer.encode(x)
-        out = np.array(out, dtype=np.uint16).view(np.uint8).tobytes()
-    else:
-        if dataset_format == "hf":
-            out = x.encode("utf8")
-        else:
-            out = x.numpy()
-    return out
+
+def tokenize_to_bytes(examples):
+    tokenized = tokenizer(examples[key])
+    tokenized["input_ids"] = [np.array(input_ids, dtype=np.uint16).view(np.uint8).tobytes() for input_ids in
+                              tokenized["input_ids"]]
+    return tokenized
+
+
+def str_to_bytes(examples):
+    examples["text"] = [text.encode("utf8") for text in examples["text"]]
+    return examples
 
 
 os.makedirs(save_dir, exist_ok=True)
-fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
-
-if num_workers > 1:
-    p = mp.Pool(96)
-else:
-    p = None
-
-i = 0
+fout = open(os.path.join(save_dir, dataset_name + "." + split), "wb")
 sizes = [0]
-if dataset_format == "hf":
-    ds = ds[key]
-for text in ds:
-    print(i)
 
-    if dataset_format == "tfds":
-        text = text[key]
-    if num_workers > 1:
-        text = p.map(tok, text)
-    else:
-        text = map(tok, text)
-    
-    for x in text:
-        next_line = sep()+x
-        fout.write(next_line)
-        sizes.append(sizes[-1]+len(next_line))
-    i += 1
+if tokenize:
+    ds = ds.map(tokenize_to_bytes, batched=True)
+    key = "input_ids"
+else:
+    ds = ds.map(str_to_bytes, batched=True)
 
-open(os.path.join(save_dir,dataset_name+"."+split+".size"), "wb").write(np.array(sizes,dtype=np.uint64).tobytes())
+for x in ds[key]:
+    next_line = sep() + x
+    fout.write(next_line)
+    sizes.append(sizes[-1] + len(next_line))
+
+open(os.path.join(save_dir, dataset_name + "." + split + ".size"), "wb").write(
+    np.array(sizes, dtype=np.uint64).tobytes())

--- a/scripts/load_dataset_hf.py
+++ b/scripts/load_dataset_hf.py
@@ -1,0 +1,109 @@
+# Copyright 2021 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow_datasets as tfds
+import tensorflow as tf
+import datasets
+import os
+import struct
+import numpy as np
+from transformers import GPT2Tokenizer
+import multiprocessing as mp
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Load a dataset.')
+parser.add_argument('--data_dir', type=str)
+parser.add_argument('--save_dir', type=str)
+parser.add_argument('--name', type=str)
+parser.add_argument('--dataset_format', type=str, default="tfds")
+parser.add_argument('--split', type=str)
+parser.add_argument('--hf_ds_subset', type=str, default=None)
+parser.add_argument('--tokenize', action='store_true')
+parser.add_argument('--text_feature_key', type=str, default="text")
+parser.add_argument('--num_workers', type=int, default=1)
+
+args = parser.parse_args()
+
+if args.tokenize:
+    tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+
+split = args.split
+data_dir = args.data_dir
+save_dir = args.save_dir
+dataset_name = args.name
+dataset_format = args.dataset_format
+key = args.text_feature_key
+num_workers = args.num_workers
+
+
+if dataset_format == "tfds":
+    ds = tfds.load(dataset_name, split=split, shuffle_files=False, batch_size=2**16,
+                   data_dir=data_dir)
+    assert isinstance(ds, tf.data.Dataset)
+    print(ds)
+elif dataset_format == "hf":
+    subset = args.hf_ds_subset
+    ds = datasets.load_dataset(dataset_name, subset, split=split)
+    assert isinstance(ds, datasets.Dataset), "This is not a HF-dataset. It might be a DatasetDict. Try passing `split`?"
+    print(ds)
+
+UID = 0
+def sep():
+    global UID
+    UID += 1
+    return b"\xff\xff"+struct.pack("<I", UID)
+
+def tok(x):
+    if args.tokenize:
+        if dataset_format == "tfds":
+            x = x.numpy().decode("utf8")
+        out = tokenizer.encode(x)
+        out = np.array(out, dtype=np.uint16).view(np.uint8).tobytes()
+    else:
+        if dataset_format == "hf":
+            out = x.encode("utf8")
+        else:
+            out = x.numpy()
+    return out
+
+
+os.makedirs(save_dir, exist_ok=True)
+fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
+
+if num_workers > 1:
+    p = mp.Pool(96)
+else:
+    p = None
+
+i = 0
+sizes = [0]
+if dataset_format == "hf":
+    ds = ds[key]
+for text in ds:
+    print(i)
+
+    if dataset_format == "tfds":
+        text = text[key]
+    if num_workers > 1:
+        text = p.map(tok, text)
+    else:
+        text = map(tok, text)
+    
+    for x in text:
+        next_line = sep()+x
+        fout.write(next_line)
+        sizes.append(sizes[-1]+len(next_line))
+    i += 1
+
+open(os.path.join(save_dir,dataset_name+"."+split+".size"), "wb").write(np.array(sizes,dtype=np.uint64).tobytes())

--- a/scripts/load_dataset_hf.py
+++ b/scripts/load_dataset_hf.py
@@ -75,8 +75,8 @@ if tokenize:
 else:
     ds = ds.map(str_to_bytes, batched=True)
 
-for x in ds[key]:
-    next_line = sep() + x
+for example in ds:
+    next_line = sep() + example[key]
     fout.write(next_line)
     sizes.append(sizes[-1] + len(next_line))
 

--- a/scripts/load_dataset_hf.py
+++ b/scripts/load_dataset_hf.py
@@ -73,7 +73,7 @@ if tokenize:
 
 for example in tqdm(ds):
     out = example[key] if tokenize else example[key].encode("utf8")
-    next_line = sep() + example[key]
+    next_line = sep() + out
     fout.write(next_line)
     sizes.append(sizes[-1] + len(next_line))
 


### PR DESCRIPTION
Hello,

This PR creates a `load_dataset_hf.py` script that allows a user to start the process from an [HF dataset ](https://github.com/huggingface/datasets). This is an independent script as the parallelizing can be done natively with the `dataset.map` method rather than with the base Python `multiprocessing` module. The usage is the same as `load_dataset.py`, with an added `text_feature_key` argument in case the dataset stores its text in a column not named `text`. I can add a usage example to the README.md if that helps.