### PR TITLE
Fix multiprocessing bug in Windows/Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Okay so maybe you don't like reading. You skipped the entire section above. (Hon
 Then just do this
 
 ```
-bash scripts/scripts/run_pipeline.sh
+bash scripts/run_pipeline.sh
 python3 scripts/finish_dedup_wiki40b.py --data_dir ~/tensorflow_datasets/ --save_dir /tmp/dedup --name wiki40b --split test --suffixarray_dir data --remove /tmp/wiki40b.test.remove.byterange
 ```
 

--- a/scripts/finish_dedup_wiki40b.py
+++ b/scripts/finish_dedup_wiki40b.py
@@ -110,7 +110,7 @@ class MyDataset(tfds.core.GeneratorBasedBuilder):
                    data_dir=args.data_dir)
     
 
-    p = mp.Pool(96)
+    p = mp.get_context("fork").Pool(mp.cpu_count())
     i = -1
     for batch in ds:
          i += 1

--- a/scripts/load_dataset.py
+++ b/scripts/load_dataset.py
@@ -74,7 +74,7 @@ if not os.path.exists(save_dir):
 
 fout = open(os.path.join(save_dir, dataset_name+"."+split), "wb")
 
-with mp.Pool(mp.cpu_count()) as p:
+with mp.get_context("fork").Pool(mp.cpu_count()) as p:
     i = 0
     sizes = [0]
     for b in ds:


### PR DESCRIPTION
The multiprocessing pool started uses the default method for launching child processes, which is OS specific. The default on Unix is "fork", and the resulting process inherits all resources from the parent process. Conversely, the default on Mac OS X/Windows is "spawn", which results in a minimal number of resources inherited by the child process.

I changed the code to explicitly use "fork", and I was able to run through the README on a Mac M1. I presume this fix would also help Windows users, though I haven't tested myself.

While I was at it, I fixed a small typo in the README.

Thanks for sharing the code and having a really nice README!