### PR TITLE
fix: off-by-one duplicate entries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1305,7 +1305,7 @@ fn cmd_merge(data_files: &Vec<String>, output_file: &String, num_threads: i64)  
                 continue;
             }
 
-            if idxs[table_index] <= ends[table_index] as u64 {
+            if idxs[table_index] < ends[table_index] as u64 {
                 let next = &texts[table_index][position as usize..];
                 //println!("  {:?}", &next[..std::cmp::min(10, next.len())]);
 


### PR DESCRIPTION
When running the `dedup_dataset merge` command with multiple parts, each shard of the merged suffix array (`*.table.bin.*`) ends up containing extra entries at thread hand-off boundaries. The probability of occurrence is very light.